### PR TITLE
feat: setup egress blocker and harness cilium to update maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,10 @@ all: $(TARGET) $(BPF_OBJ)
 .PHONY: $(TARGET)
 
 $(TARGET): $(BPF_OBJ)
-	bpftool net detach xdp dev lo
 	rm -f /sys/fs/bpf/$(TARGET)
-	bpftool prog load $(BPF_OBJ) /sys/fs/bpf/$(TARGET)
 	tc qdisc add dev eth0 clsact
 	tc filter add dev eth0 ingress bpf direct-action obj $(BPF_OBJ) sec tc/ingress
+	tc filter add dev eth0 egress bpf direct-action obj $(BPF_OBJ) sec tc/egress
 
 $(BPF_OBJ): %.o: %.c vmlinux.h
 	clang \
@@ -28,6 +27,6 @@ vmlinux.h:
 	bpftool btf dump file /sys/kernel/btf/vmlinux format c > vmlinux.h		
 
 clean:
-	- rm -f /sys/fs/bpf/$(TARGET)
-	- rm $(BPF_OBJ)
 	- tc qdisc del dev eth0 clsact
+	- rm -rf /sys/fs/bpf/tc
+	- rm $(BPF_OBJ)

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,0 +1,9 @@
+module github.com/kwakubiney/inferno
+
+go 1.21.0
+
+require (
+	github.com/cilium/ebpf v0.11.0 // indirect
+	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+)

--- a/client/go.sum
+++ b/client/go.sum
@@ -1,0 +1,6 @@
+github.com/cilium/ebpf v0.11.0 h1:V8gS/bTCCjX9uUnkUFUpPsksM8n1lXBAvHcpiFk1X2Y=
+github.com/cilium/ebpf v0.11.0/go.mod h1:WE7CZAnqOL2RouJ4f1uyNhqr2P4CCvXFIqdRDUgWsVs=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/client/main.go
+++ b/client/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/cilium/ebpf"
+)
+
+func convertIPtoU32(address string) uint32 {
+	ipAsAByte := net.ParseIP(address).To4()
+	return binary.LittleEndian.Uint32(ipAsAByte)
+}
+
+const (
+	ingress = "blocked"
+)
+
+func main() {
+	var ipToBeBlockedFromIngress = flag.String("ingress", "", "this blocks ingress traffic having the given source IP address")
+	var ipToBeBlockedToEgress = flag.String("egress", "", "this blocks egress traffic having the given destination IP address")
+	flag.Parse()
+	if *ipToBeBlockedFromIngress != "" || *ipToBeBlockedToEgress != "" {
+		loadPinOptions := ebpf.LoadPinOptions{}
+		blockedMap, err := ebpf.LoadPinnedMap(fmt.Sprintf("/sys/fs/bpf/tc/globals/%s", ingress), &loadPinOptions)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if *ipToBeBlockedFromIngress != "" {
+			err = blockedMap.Put(convertIPtoU32(*ipToBeBlockedFromIngress), uint32(0))
+			fmt.Println("ingress detected")
+			fmt.Println("-----------------")
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("ingress traffic from %s sucessfully blocked\n", *ipToBeBlockedFromIngress)
+		}
+		if *ipToBeBlockedToEgress != "" {
+			err = blockedMap.Put(convertIPtoU32(*ipToBeBlockedToEgress), uint32(1))
+			fmt.Println("egress detected")
+			fmt.Println("-----------------")
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("egress traffic to %s sucessfully blocked\n", *ipToBeBlockedToEgress)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+	} else {
+		flag.Usage()
+	}
+}

--- a/firewall.c
+++ b/firewall.c
@@ -1,3 +1,4 @@
+#include <bits/types.h>
 #include <linux/bpf.h>
 #include <linux/pkt_cls.h>
 #include <stdint.h>
@@ -12,8 +13,8 @@ struct {
     __type(key, __u32);
     __type(value, __u32);
     __uint(max_entries, 20000);
+    __uint(pinning, LIBBPF_PIN_BY_NAME);
 } blocked SEC(".maps");
-
 
 SEC("tc/ingress")
 int process_ingress_pkt(struct __sk_buff *skb){
@@ -38,18 +39,55 @@ int process_ingress_pkt(struct __sk_buff *skb){
   		return TC_ACT_SHOT;
 	}
 
-	long *blocked_ip;
+	uint32_t *blocked_source_ip;
     struct iphdr *ip = (data + sizeof(struct ethhdr));
 
     if (data + sizeof(struct ethhdr) + sizeof(struct iphdr) > data_end) {
         return TC_ACT_SHOT;
     }
-
-    blocked_ip = bpf_map_lookup_elem(&blocked, &(ip->saddr));
-	if (blocked_ip == NULL) {
-         return TC_ACT_OK;
+    blocked_source_ip = bpf_map_lookup_elem(&blocked, &(ip->saddr));
+	if (blocked_source_ip != NULL && *blocked_source_ip == (uint32_t)0) {
+         return TC_ACT_SHOT;
     }else{
-	    return TC_ACT_SHOT;
+        return TC_ACT_OK;
+    }
+}
+
+
+SEC("tc/egress")
+int process_egress_pkt(struct __sk_buff *skb){
+    void *data = (void *)(long)skb->data;
+    void *data_end = (void *)(long)skb->data_end;
+
+    if (data > data_end) {
+        return TC_ACT_SHOT;
+    }
+
+    struct ethhdr *eth_hdr = data;
+
+    if ((void *) (eth_hdr + 1) > data_end) {
+        return TC_ACT_OK;
+    }
+
+    if (eth_hdr->h_proto != bpf_htons(ETH_P_IP)) {
+        return TC_ACT_OK;
+    }
+
+    if (data + sizeof(struct ethhdr) + sizeof(struct iphdr) > data_end){
+  		return TC_ACT_SHOT;
+	}
+
+	uint32_t *blocked_destination_ip;
+    struct iphdr *ip = (data + sizeof(struct ethhdr));
+
+    if (data + sizeof(struct ethhdr) + sizeof(struct iphdr) > data_end) {
+        return TC_ACT_SHOT;
+    }
+    blocked_destination_ip = bpf_map_lookup_elem(&blocked, &(ip->daddr));
+	if (blocked_destination_ip != NULL && *blocked_destination_ip == (uint32_t)1) {
+         return TC_ACT_SHOT;
+    }else{
+        return TC_ACT_OK;
     }
 }
 


### PR DESCRIPTION
This commit sets up the egress traffic control hook to prevent egress traffic to specific IP addresses. It also cleans up some bugs on the ingress side as well. Initially, maps were being created twice because I was using bpftool and tc at the same time and both create two different maps. This commit removes all bpftool usages and relies on tc to create maps and also delete maps.